### PR TITLE
Update requirements.txt to pin pg8000 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask>=1.0
 Flask-SQLAlchemy>=2.4
-pg8000
+pg8000<1.16.6
 python-dotenv


### PR DESCRIPTION
Due to this error:
https://github.com/juju/hello-juju-charm/issues/1

Which seems to be this underlying issue
https://github.com/sqlalchemy/sqlalchemy/issues/5645

It seems the best way forward is to pin the version of pg8000